### PR TITLE
Feat/generate teams

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
-		"test": "npm run test:integration && npm run test:unit",
+		"test": "pnpm run test:integration && pnpm run test:unit",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",

--- a/src/lib/components/EventCard.svelte
+++ b/src/lib/components/EventCard.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-	import type { Player } from '$lib/types/player.types';
-	import type { GameEvent } from '$lib/types/game.types';
-	import { createContentfulGameEventText } from '$lib/helper';
+
 </script>
 
 <div />

--- a/src/lib/components/TeamCard.svelte
+++ b/src/lib/components/TeamCard.svelte
@@ -2,7 +2,7 @@
 	import type { Team } from '$lib/types/team.types';
 	import PlayerCard from './player/PlayerCard.svelte';
 	export let team: Team;
-	export let showMotto = true;
+	export let showMotto = false;
 </script>
 
 <div class="flex flex-col items-center">

--- a/src/lib/components/TeamCard.svelte
+++ b/src/lib/components/TeamCard.svelte
@@ -1,21 +1,23 @@
 <script lang="ts">
+	import { TEAM_SIZE } from '$lib/constants';
 	import type { Team } from '$lib/types/team.types';
 	import PlayerCard from './player/PlayerCard.svelte';
+	
 	export let team: Team;
 	export let showMotto = false;
 </script>
 
 <div class="flex flex-col items-center">
-	<div class="text-center mb-1">
-		<h1 class="text-sm font-sans font-semibold">{team.name}</h1>
+	<div class="text-center mb-1 w-full">
+		<h1 class="text-sm font-sans font-semibold border-b-2">{ 1 < TEAM_SIZE ? team.name : `#${team.name.match(/\d+/)}`}</h1>
 		{#if showMotto}
 			<p class="text-xs font-serif font-light w-48 flex flex-column justify-center">
 				“<span class="block truncate">{team.motto}</span>”
 			</p>
 		{/if}
 	</div>
-	<div class="flex flex-row flex-wrap justify-between">
-		{#each team.players as player}
+	<div class="flex flex-row flex-wrap justify-center">
+		{#each team.players as player}	
 			<PlayerCard {player} />
 		{/each}
 	</div>

--- a/src/lib/components/player/PlayerCard.svelte
+++ b/src/lib/components/player/PlayerCard.svelte
@@ -11,7 +11,7 @@
 	const dead_grayscale = player.status === DEAD ? 'grayscale' : '';
 </script>
 
-<div class="text-center w-20 flex flex-col">
+<div class="text-center w-24 flex flex-col">
 	{#if showImage}
 		<img
 			class="mx-auto inset-0 object-contain w-10/12 text-xs {dead_grayscale}"
@@ -21,7 +21,7 @@
 		/>
 	{/if}
 	<p class="text-xs font-bold overflow-wrap break-word">
-		{player.givenName}
+		{`${player.givenName} ${player.familyName}`}
 	</p>
 	<div class="font-semibold text-xs flex flex-row gap-1.5 justify-center items-center">
 		{#if 0 < player.kills && showKillCount}

--- a/src/lib/components/player/PlayerCard.svelte
+++ b/src/lib/components/player/PlayerCard.svelte
@@ -5,7 +5,7 @@
 	import PlayerStatus from './PlayerStatus.svelte';
 	export let player: Player;
 	// Settings
-	export let showImage: boolean = true;
+	export let showImage: boolean = false;
 	export let showKillCount: boolean = true;
 
 	const dead_grayscale = player.status === DEAD ? 'grayscale' : '';

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,6 +1,6 @@
-import { generatePronounRegExpStrings } from './helper';
-import type { Gender, PronounType } from './types/gender_and_pronouns.types';
+import type { Gender, PronounRegexStrings, PronounType } from '$lib/types/gender_and_pronouns.types';
 
+// TODO: switch 'gender' to enum?
 // Genders
 export const MALE: Gender = {
 	gender: 'male',
@@ -31,11 +31,13 @@ export const NON_BINARY: Gender = {
 };
 export const GENDERS: Gender[] = [MALE, FEMALE, NON_BINARY];
 
+// TODO: switch to enum?
 // Pronoun Types
 export const SUBJECT_PRONOUN = 'subject';
 export const OBJECT_PRONOUN = 'object';
 export const POSSESSIVE_PRONOUN = 'possessive';
 export const REFLEXIVE_PRONOUN = 'reflexive';
+
 export const PRONOUNS: PronounType[] = [
 	SUBJECT_PRONOUN,
 	OBJECT_PRONOUN,
@@ -50,7 +52,35 @@ export const GAME_EVENT_TEXT_PLAYER_REGEX = /\(Player(\d+)\)/g;
 export const GAME_EVENT_TEXT_PRONOUN_DYNAMIC_REGEX = (pronouns: string) =>
 	`\\((${pronouns})(\\d+)\\)`;
 export const GAME_EVENT_TEXT_PRONOUN_DIVIDER = '/';
-// The regex strings for all pronoun types
+// This function has to be here, and not in ./helper.ts. I don't know why, but I get a TypeError
+// when I try to import it from ./helper.ts, saying that
+// "__vite_ssr_import_0__.generatePronounRegExpStrings is not a function" :D
+// I tried to make it async in ./helper.ts and await it here, but that didn't work.
+const generatePronounRegExpStrings = (genders: Gender[]): PronounRegexStrings => {
+	// This type is used to access the keys of the PronounRegexStrings object
+	// in ./constants.ts based on the PronounType keys.
+	const regExpStrings: PronounRegexStrings = {
+		subject: '',
+		object: '',
+		possessive: '',
+		reflexive: ''
+	};
+
+	// For each pronoun type, generate a regex string
+	PRONOUNS.forEach((pronounType) => {
+		let regexString = '';
+		// with values from each gender
+		genders.forEach((gender, index) => {
+			const isLastGender = index === genders.length - 1;
+			// appended and seprarated by the divider
+			regexString += isLastGender
+				? `${gender.pronouns[pronounType]}` // Don't append the divider
+				: `${gender.pronouns[pronounType]}\\${GAME_EVENT_TEXT_PRONOUN_DIVIDER}`; // Append the divider
+			regExpStrings[pronounType] = GAME_EVENT_TEXT_PRONOUN_DYNAMIC_REGEX(regexString);
+		});
+	});
+	return regExpStrings;
+};
 const PRONOUN_REGEX_STRINGS = generatePronounRegExpStrings(GENDERS);
 // Pronouns Regexes set with Flag 'g'
 export const SUBJECT_PRONOUN_REGEX = new RegExp(PRONOUN_REGEX_STRINGS[SUBJECT_PRONOUN], 'g');
@@ -58,11 +88,16 @@ export const OBJECT_PRONOUN_REGEX = new RegExp(PRONOUN_REGEX_STRINGS[OBJECT_PRON
 export const POSSESSIVE_PRONOUN_REGEX = new RegExp(PRONOUN_REGEX_STRINGS[POSSESSIVE_PRONOUN], 'g');
 export const REFLEXIVE_PRONOUN_REGEX = new RegExp(PRONOUN_REGEX_STRINGS[REFLEXIVE_PRONOUN], 'g');
 
+// TODO: switch to enum?
 // Player Status
 export const ALIVE = 'alive';
 export const DEAD = 'dead';
 
+// TODO: switch to enum?
 // Team Status
 export const ACTIVE = 'active';
 export const ELIMINATED = 'eliminated';
 export const DISQUALIFIED = 'disqualified';
+
+// Team
+export const TEAM_SIZE = 3;

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,47 +1,27 @@
-import type { Team } from './types/team.types';
-import { ACTIVE } from './constants';
-import { createMultiplePlayers } from './helper';
-
-const hunger_games_characters = [
-	'Katniss, Everdeen, Girl on Fire, female',
-	'Peeta, Mellark, The Boy with the Bread, male',
-	'Gale, Hawthorne, The Hunter, male',
-	'Haymitch, Abernathy, Haymitch, male',
-	'Effie, Trinket, Effie, female',
-	'Cinna, None, Cinna, male',
-	'Primrose, Everdeen, Prim, female',
-	'Rue, None, Rue, female',
-	'Thresh, None, Thresh, male',
-	'Cato, None, Cato, male',
-	'Clove, None, Clove, female',
-	'Foxface, None, Foxface, female',
-	'Finnick, Odair, Finnick, male',
-	'Johanna, Mason, Johanna, female',
-	'Beetee, Latier, Beetee, male',
-	'Wiress, None, Wiress, female',
-	'Enobaria, None, Enobaria, female',
-	'Boggs, None, Boggs, male',
-	'Pollux, None, Pollux, male',
-	'Coriolanus, Snow, President Snow, male',
-	'Alma, Coin, President Coin, female'
+export const character_data = [
+	"John, Smith, Maverick, male",
+	"Emily, Davis, Sparkle, female",
+	"Alex, Johnson, Innovator, non-binary",
+	"Sarah, Williams, Sunshine, female",
+	"Michael, Brown, Explorer, male",
+	"Taylor, Anderson, Trailblazer, non-binary",
+	"Jessica, Lee, Dreamer, female",
+	"David, Martinez, Techie, male",
+	"Emma, Taylor, Enigma, female",
+	"Ryan, Robinson, Visionary, male",
+	"Taylor, Clark, Catalyst, non-binary",
+	"Olivia, Turner, Melody, female",
+	"Jordan, White, Whiz, non-binary",
+	"Matthew, King, Genius, male",
+	"Sophia, Garcia, Luminary, female",
+	"Avery, Wright, Voyager, non-binary",
+	"Lily, Moore, Serenity, female",
+	"Ethan, Parker, Innovator, male",
+	"Harper, Hall, Spark, non-binary",
+	"Benjamin, Lewis, Scholar, male",
+	"Mia, Adams, Harmony, female",
+	"Riley, Wilson, Pioneer, non-binary",
+	"Chloe, Harris, Artist, female",
+	"Mason, Carter, Maestro, male",
+	"Kim Isak, Olsen, Kimmi, male",
 ];
-
-const players = createMultiplePlayers(hunger_games_characters);
-
-const team1: Team = {
-	name: 'Team 1',
-	motto: 'We are number one',
-	players: [players[1], players[2]],
-	leader: players[1],
-	status: ACTIVE
-};
-
-const team2: Team = {
-	name: 'Team 2',
-	motto: 'Second to none except team 1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-	players: [players[3], players[4]],
-	leader: players[3],
-	status: ACTIVE
-};
-
-export const teams = [team1, team2, team2, team2, team2, team2, team1];

--- a/src/lib/types/gender_and_pronouns.types.ts
+++ b/src/lib/types/gender_and_pronouns.types.ts
@@ -6,6 +6,14 @@ type ReflexivePronoun = 'himself' | 'herself' | 'themself';
 export type Pronouns = SubjectPronoun | ObjectPronoun | PossessivePronoun | ReflexivePronoun;
 export type PronounType = 'subject' | 'object' | 'possessive' | 'reflexive';
 
+// This type could probably be moved, but it's only used in the following function.
+export type PronounRegexStrings = {
+	subject: string;
+	object: string;
+	possessive: string;
+	reflexive: string;
+};
+
 export type GenderPronouns = {
 	subject: SubjectPronoun;
 	object: ObjectPronoun;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,18 +1,13 @@
 <script lang="ts">
-	import '../app.css';
-	import { teams } from '$lib/data';
 	import TeamCard from '$lib/components/TeamCard.svelte';
-	import EventCard from '$lib/components/EventCard.svelte';
-	import type { Team } from '$lib/types/team.types';
-	import type { Player } from '$lib/types/player.types';
+	import '../app.css';
+	import type { PageData } from './$types';
 
-	const all_players: Player[] = teams.reduce((acc: Player[], team: Team) => {
-		return acc.concat(team.players);
-	}, []);
+	export let data: PageData;
 </script>
 
-<main class="p-10 flex flex-col sm:flex-row sm:flex-wrap gap-10 w-full justify-evenly">
-	{#each teams as team}
+<main class="p-10 flex flex-col sm:flex-row sm:flex-wrap gap-10 w-full justify-center">
+	{#each data.teams as team}
 		<TeamCard {team} />
 	{/each}
 </main>

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,0 +1,13 @@
+import { character_data } from '$lib/data';
+import { createMultiplePlayers, createMultipleTeams, playersNameCount } from '$lib/helper';
+
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = () => {
+	const players = createMultiplePlayers(character_data);
+	return {
+		players,
+		playerNameCount: playersNameCount(players),
+		teams: createMultipleTeams(players)
+	};
+};

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,2 +1,0 @@
-import { goto } from '$app/navigation';
-import { expect, test } from '@playwright/test';


### PR DESCRIPTION
# Lots of changes
- Added PageLoader with `page.ts` to initiate data
- Conditional render on Team Name given Team Size.
- Show Player givenName and familyName in PlayerCard
- Move `generatePronounRegExpStrings` from `helper` to `constant` to not break at runtime for unknown reasons despite hypotheses of why. Added comment about it.
- Added new constant, `TEAM_SIZE`
- Added comments about switching some String literal types to Enums
- Updated character mock data for testing. In the future, the character data should be provided with user inputs.
- Moved `type PronounRegexStrings` to a more fitting type file.
- Render Team with PageLoad data